### PR TITLE
Add missing "Permission"

### DIFF
--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 Copyright  2018 Succo
 
-is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 


### PR DESCRIPTION
The MIT text was truncated. This adds the missing start from
https://opensource.org/licenses/mit

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>